### PR TITLE
Make image responsive: optional attribute added to not include height and width attributes in HTML markup

### DIFF
--- a/dynamic_img_resize.php
+++ b/dynamic_img_resize.php
@@ -485,9 +485,9 @@ SQL;
 	{
 		return sprintf(
 			'<img %s %s %s />',
-			"{src='$src'}",
+			"src=\"$src\"",
 			$hw_string,
-			! empty( $classes ) ? "class='{$classes}'" : ''
+			! empty( $classes ) ? "class=\"$classes\"" : ''
 		);
 	}
 } // END Class oxoDynamicImageResize


### PR DESCRIPTION
I'm using your plugin in a responsive template. To make images adaptive, I needed the `img` markup free from `height` and `width` attributes.

So I added an optional attribute (`hw_markup`) which controls the image HTML output.

`hw_markup` accepts `0` or `1` values.

Here is how it works:

```
// Outputs default markup:
echo dynamic_image_resize( array(
    'src' => array_shift( wp_get_attachment_image_src(
            get_post_thumbnail_id( get_the_ID() ),
            "Full"
        ) ),
    'width'   => 60,
    'height'  => 101,
    'classes' => 'thumb',
    'hw_markup' => 1
 ) );

// Outputs markup without width/height attrs:
echo dynamic_image_resize( array(
    'src' => array_shift( wp_get_attachment_image_src(
            get_post_thumbnail_id( get_the_ID() ),
            "Full"
        ) ),
    'width'   => 60,
    'height'  => 101,
    'classes' => 'thumb',
    'hw_markup' => 0
 ) );

// hw_markup attribute omitted: outputs image with standard markup
echo dynamic_image_resize( array(
    'src' => array_shift( wp_get_attachment_image_src(
            get_post_thumbnail_id( get_the_ID() ),
            "Full"
        ) ),
    'width'   => 60,
    'height'  => 101,
    'classes' => 'thumb'
) );
```

Thanks for your great script. Greetings!
